### PR TITLE
pin npm-delegate version to 0.2.x

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -39,4 +39,4 @@ curl -k "http://localhost:5984/registry/_design/scratch" -X COPY -H destination:
 curl http://isaacs.iriscouch.com/registry/error%3A%20forbidden | curl -X PUT -d @- http://localhost:5984/registry/error%3A%20forbidden?new_edits=false
 
 # Installing npm-delegate
-npm install -g npm-delegate
+npm install -g npm-delegate@0.2.x


### PR DESCRIPTION
For added stability to the built docker image, install a specific version of npm-delegate.

There are a few pending pull requests that people are working on. I'll be sure to use semver to preserve interface compatibility for specific versions, but if people are depending on this Docker image, I want to provide a measure of stability.
