### PR TITLE
fixing kappa install & startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ RUN cd /opt/npmjs; git checkout ea8e7a533ea595db79b24f12c76b62c3889b43e8
 RUN npm install couchapp@0.10.x -g
 RUN cd /opt/npmjs; npm link couchapp; npm install semver
 
+# Download kappa
+RUN npm install -g kappa@0.14.3
+
 # Allow insecure rewrites
 RUN echo "[httpd]\nsecure_rewrites = false" >> /usr/local/etc/couchdb/local.d/secure_rewrites.ini
 

--- a/config/kappa.json.default
+++ b/config/kappa.json.default
@@ -6,15 +6,14 @@
 		}
 	],
 	"plugins": {
-		"kappa": [
-			{},
+		"kappa":
 			{
+				"hostname": "${hostname}",
 				"paths": [
 					"http://${hostname}:5984/",
 					"https://registry.npmjs.org/",
 					"http://npm.nodejs.org.au:5984/registry/_design/app/_rewrite"
 				]
 			}
-		]
 	}
 }

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-echo -e "[vhosts]\n$HOSTNAME:5984 = /registry/_design/app/_rewrite" >> /usr/local/etc/couchdb/local.d/npmjs-vhost.ini
-echo -e "127.0.0.1\t$HOSTNAME" >> /etc/hosts
-cat /opt/npmjs/kappa.json.default|sed -e "s/\${hostname}/$HOSTNAME/" > /opt/npmjs/kappa.json
-couchdb -b; hapi -c /opt/npmjs/kappa.json & tail -f /usr/local/var/log/couchdb/couch.log
+FULLHOST=$(hostname -f)
+echo -e "[vhosts]\n$FULLHOST:5984 = /registry/_design/app/_rewrite" >> /usr/local/etc/couchdb/local.d/npmjs-vhost.ini
+cat /opt/npmjs/kappa.json.default|sed -e "s/\${hostname}/$FULLHOST/" > /opt/npmjs/kappa.json
+couchdb -b; kappa -c /opt/npmjs/kappa.json & tail -f /usr/local/var/log/couchdb/couch.log

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-echo -e "[vhosts]\n$HOSTNAME:5984 = /registry/_design/app/_rewrite" >> /usr/local/etc/couchdb/local.d/npmjs-vhost.ini
-echo -e "127.0.0.1\t$HOSTNAME" >> /etc/hosts
-cat /opt/npmjs/kappa.json.default|sed -e "s/\${hostname}/$HOSTNAME/" > /opt/npmjs/kappa.json
-couchdb -b; hapi -c /opt/npmjs/kappa.json & tail -f /usr/local/var/log/couchdb/couch.log
+FULLHOST=$(hostname -f)
+echo -e "[vhosts]\n$FULLHOST:5984 = /registry/_design/app/_rewrite" >> /usr/local/etc/couchdb/local.d/npmjs-vhost.ini
+echo -e "127.0.0.1\t$FULLHOST" >> /etc/hosts
+cat /opt/npmjs/kappa.json.default|sed -e "s/\${hostname}/$FULLHOST/" > /opt/npmjs/kappa.json
+couchdb -b; kappa -c /opt/npmjs/kappa.json & tail -f /usr/local/var/log/couchdb/couch.log


### PR DESCRIPTION
This attempts to fix the container for:
- `/etc/hosts` being un-writable (see: https://github.com/dotcloud/docker/issues/2267)
- kappa (and hapi) not being installed (anywhere I could find it at least)
- kappa config being wrong (starting kappa with the config caused kappa to blow up)

Should fix #25
