### PR TITLE
Newer couch, new kappa, new kapp setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-# Version: 0.5.2 28-Feb-2014
-FROM sbisbee/couchdb:1.4
+# Version: 0.5.2 28-Feb-201
+FROM fedora/couchdb
 MAINTAINER Terin Stock <terinjokes@gmail.com>
 
 ENV PATH /opt/node/bin/:$PATH
 
 # Install curl
-RUN apt-get install -y curl git
+RUN yum install -y curl git
 
 # Setup nodejs
-RUN mkdir -p /opt/node
-RUN curl -L# http://nodejs.org/dist/v0.10.26/node-v0.10.26-linux-x64.tar.gz|tar -zx --strip 1 -C /opt/node
+RUN curl -sL https://rpm.nodesource.com/setup | bash -
+RUN yum install -y nodejs
 
 # Download npmjs project
 RUN git clone https://github.com/isaacs/npmjs.org /opt/npmjs
@@ -18,7 +18,7 @@ RUN npm install couchapp@0.10.x -g
 RUN cd /opt/npmjs; npm link couchapp; npm install semver
 
 # Allow insecure rewrites
-RUN echo "[httpd]\nsecure_rewrites = false" >> /usr/local/etc/couchdb/local.d/secure_rewrites.ini
+RUN echo -e "[httpd]\nsecure_rewrites = false" >> /etc/couchdb/local.d/secure_rewrites.ini
 
 # Configuring npmjs.org
 RUN cd /opt/npmjs; couchdb -b; sleep 5; curl -X PUT http://localhost:5984/registry; sleep 5; couchdb -d;
@@ -26,12 +26,11 @@ RUN cd /opt/npmjs; couchdb -b; sleep 5; couchapp push registry/shadow.js http://
 RUN cd /opt/npmjs; npm set _npmjs.org:couch=http://localhost:5984/registry
 RUN cd /opt/npmjs; couchdb -b; sleep 5; npm run load; sleep 5; curl -k "http://localhost:5984/registry/_design/scratch" -X COPY -H destination:'_design/app'; sleep 5; couchdb -d
 ## Resolve isaacs/npmjs.org#98
-RUN cd /opt/npmjs; /usr/local/bin/couchdb -b; sleep 5; curl http://isaacs.iriscouch.com/registry/error%3A%20forbidden | curl -X PUT -d @- http://localhost:5984/registry/error%3A%20forbidden?new_edits=false; sleep 5; couchdb -d
-
-# Install npm-delegate
-RUN npm install -g kappa@0.14.x
+RUN cd /opt/npmjs; /usr/bin/couchdb -b; sleep 5; curl http://isaacs.iriscouch.com/registry/error%3A%20forbidden | curl -X PUT -d @- http://localhost:5984/registry/error%3A%20forbidden?new_edits=false; sleep 5; couchdb -d
 
 # Start
+ADD config/package.json /opt/npmjs/package.json
+RUN cd /opt/npmjs/ && npm install
 ADD config/kappa.json.default /opt/npmjs/kappa.json.default
 ADD scripts/startup.sh /root/startup.sh
 CMD /root/startup.sh

--- a/config/kappa.json.default
+++ b/config/kappa.json.default
@@ -6,15 +6,17 @@
 		}
 	],
 	"plugins": {
-		"kappa": [
-			{},
-			{
-				"paths": [
-					"http://${hostname}:5984/",
-					"https://registry.npmjs.org/",
-					"http://npm.nodejs.org.au:5984/registry/_design/app/_rewrite"
-				]
+		"kappa": {
+			"paths": [
+				"http://${hostname}:5984/",
+				"https://registry.npmjs.org/",
+				"https://registry.nodejs.org.au/"
+			]
+		},
+		"good": {
+			"subscribers": {
+				"console": ["request", "ops", "log", "error"]
 			}
-		]
+		}
 	}
 }

--- a/config/package.json
+++ b/config/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "mykappa",
+  "version": "0.0.0",
+  "description": "Personal NPM registry",
+  "scripts": {
+    "start": "kappa -c kappa.json"
+  },
+  "dependencies": {
+    "good": "~2.3.0",
+    "hapi": "~6.9.0",
+    "kappa": "~1.0.0-rc.1"
+  }
+}

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-echo -e "[vhosts]\n$HOSTNAME:5984 = /registry/_design/app/_rewrite" >> /usr/local/etc/couchdb/local.d/npmjs-vhost.ini
+echo -e "[vhosts]\n$HOSTNAME:5984 = /registry/_design/app/_rewrite" >> /etc/couchdb/local.d/npmjs-vhost.ini
 echo -e "127.0.0.1\t$HOSTNAME" >> /etc/hosts
 cat /opt/npmjs/kappa.json.default|sed -e "s/\${hostname}/$HOSTNAME/" > /opt/npmjs/kappa.json
-couchdb -b; hapi -c /opt/npmjs/kappa.json & tail -f /usr/local/var/log/couchdb/couch.log
+couchdb -b; cd /opt/npmjs/; npm start & tail -f /var/log/couchdb/couch.log


### PR DESCRIPTION
I needed this for some testing so brought it up to date. The only thing that's not updated is the commit you're basing npmjs on, there's too much crazy to yak shave an update to that! 

I switched to a different couchdb Docker container, I went by download popularity on Docker Hub and picked a fedora-based one.

Kappa is at v1rc and Hapi is version 6. I've also bundled them into a package with a package.json so it doesn't need the `-g` install at all, just an `npm start`.

Seems to be working OK so far, but this is npm after all so who knows!
